### PR TITLE
Tiny little bit of refactoring

### DIFF
--- a/src/components/Modals/GetStarted/GetStartedModalContent.vue
+++ b/src/components/Modals/GetStarted/GetStartedModalContent.vue
@@ -210,7 +210,7 @@ export default {
       this.slide = this.slides[this.slides.indexOf(this.slide) + 1];
     },
     done() {
-      this.$root.$emit('getStartedModalOpened', false);
+      this.$store.dispatch('setup/setGetStartedModalOpened', false);
       this.$store.dispatch('setup/setAccountType', 'new');
       this.$router.push({ path: '/setup/2' });
     },

--- a/src/components/Modals/GetStarted/index.vue
+++ b/src/components/Modals/GetStarted/index.vue
@@ -21,15 +21,15 @@ export default {
   components: {
     GetStartedModalContent,
   },
-  data() {
-    return {
-      getStartedModalOpened: false,
-    };
-  },
-  mounted() {
-    this.$root.$on('getStartedModalOpened', (value) => {
-      this.getStartedModalOpened = value;
-    });
+  computed: {
+    getStartedModalOpened: {
+      get() {
+        return this.$store.state.setup.getStartedModalOpened;
+      },
+      set(value) {
+        this.$store.dispatch('setup/setGetStartedModalOpened', value);
+      },
+    },
   },
 };
 </script>

--- a/src/pages/Setup/Steps/Splash/index.vue
+++ b/src/pages/Setup/Steps/Splash/index.vue
@@ -131,7 +131,7 @@ export default {
     },
 
     getStarted() {
-      this.$root.$emit('getStartedModalOpened', true);
+      this.$store.dispatch('setup/setGetStartedModalOpened', true);
     },
   },
 };

--- a/src/store/setup/__mocks__/setup.js
+++ b/src/store/setup/__mocks__/setup.js
@@ -7,6 +7,7 @@ const actions = {
   setPinConfirm: jest.fn(),
   setPin: jest.fn(),
   clearSetupData: jest.fn(),
+  setGetStartedModalOpened: jest.fn(),
 };
 const getters = {};
 const mutations = {};

--- a/src/store/setup/actions.js
+++ b/src/store/setup/actions.js
@@ -110,3 +110,10 @@ export function resetPinConfirm(context) {
 export function clearSetupData(context) {
   context.commit('CLEAR_SETUP_DATA');
 }
+
+/**
+ * Action setGetStartedModalOpened
+ */
+export function setGetStartedModalOpened(context, payload) {
+  context.commit('SET_GETSTARTED_MODAL_OPENED', payload);
+}

--- a/src/store/setup/mutations.js
+++ b/src/store/setup/mutations.js
@@ -125,3 +125,10 @@ export function CLEAR_SETUP_DATA(state) {
   state.seed = null;
   state.spvMode = null;
 }
+
+/**
+ * Set GetStarted modal opened
+ */
+export function SET_GETSTARTED_MODAL_OPENED(state, payload) {
+  state.getStartedModalOpened = payload;
+}

--- a/src/store/setup/state.js
+++ b/src/store/setup/state.js
@@ -11,4 +11,5 @@ export default {
   accountLocale: null,
   accountIpNode: null,
   accountCurrency: null,
+  getStartedModalOpened: false,
 };

--- a/test/jest/__tests__/components/Modals/GetStarted/GetStartedModalContent.spec.js
+++ b/test/jest/__tests__/components/Modals/GetStarted/GetStartedModalContent.spec.js
@@ -72,11 +72,9 @@ describe('GetStartedModalContent component', () => {
   });
 
   describe('done() method', () => {
-    it('emits getStartedModalOpened with value false', () => {
-      const callback = jest.fn();
-      wrapper.vm.$root.$on('getStartedModalOpened', callback);
+    it('dispatches setGetStartedModalOpened with false as payload', () => {
       wrapper.vm.done();
-      expect(callback).toHaveBeenCalledWith(false);
+      expect(storeMocks.actions.setGetStartedModalOpened.mock.calls[0][1]).toBe(false);
     });
 
     it('dispatches setAccountType with \'new\' as payload', () => {

--- a/test/jest/__tests__/pages/Setup/Steps/Splash/Splash.spec.js
+++ b/test/jest/__tests__/pages/Setup/Steps/Splash/Splash.spec.js
@@ -40,15 +40,9 @@ describe('Splash Setup', () => {
   });
 
   describe('Get Started button', () => {
-    it('emits getStartedModalOpened event when clicked', async (done) => {
-      const callback = jest.fn();
-      wrapper.vm.$root.$on('getStartedModalOpened', callback);
+    it('dispatches setGetStartedModalOpened with false as payload', () => {
       wrapper.find('.get-started-btn').trigger('click');
-
-      wrapper.vm.$nextTick(() => {
-        expect(callback).toHaveBeenCalled();
-        done();
-      });
+      expect(storeMocks.actions.setGetStartedModalOpened.mock.calls[0][1]).toBe(true);
     });
   });
 


### PR DESCRIPTION
To test the GetStarted modal I moved its contents into its own component, this broke the `this.$root.emit` events. Instead of going with global `app.$emit` I quickly refactored it.